### PR TITLE
add query route for unknown categories (Fixes #256)

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -12,6 +12,7 @@ class App extends Component {
                     <Home path="/"/>
                     <Status path="/status/"/>
                     {/* Reach does not have native support for a slash in the url, hence two Query paths */}
+                    <Query path="/query/:query" />
                     <Query path="/:category/:query"/>
                     <Query path="/:category/:query1/:query2"/>
                     <Redirect default from="/" to="/" noThrow/>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -12,7 +12,7 @@ class App extends Component {
                     <Home path="/"/>
                     <Status path="/status/"/>
                     {/* Reach does not have native support for a slash in the url, hence two Query paths */}
-                    <Query path="/query/:query" />
+                    <Query path="/query/:query"/>
                     <Query path="/:category/:query"/>
                     <Query path="/:category/:query1/:query2"/>
                     <Redirect default from="/" to="/" noThrow/>


### PR DESCRIPTION
I have added a route for `/query/:query`, which is used by the AS-SET results page. This fixes #256 

An example page where the issue occurs is https://irrexplorer.nlnog.net/as-set/AS20473:AS-CONE (open any member in a new tab). Clicking any of the invalid member links works in the current tab as it is handled by the router.

Another possible solution is to implement a subset of https://github.com/NLNOG/irrexplorer/blob/9f9b7a86b735d140aa38bbbbde0d6f8bc97d7e89/irrexplorer/api/queries.py#L40-L65 client-side in order to determine correct routing locally.

It is not feasible to query `clean_query` for every result as suggested in the original issue, especially on large AS-SETs.

Please let me know if the latter solution is preferred.