### PR TITLE
feat: simplifying dev environment and required infra/services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 .tmpdirs
 .pytest_cache
 /.env
+dev/data/
+venv/
 
 syntax: glob
 __pycache__

--- a/README.md
+++ b/README.md
@@ -146,3 +146,80 @@ This also allow auto reloading.
 To run tests, run `yarn build` (or `poetry run frontend-build`) at least once
 (that build is used for static serving tests), activate the virtualenv,
 then run `pytest`.
+
+### Setting up a Development Environment with Docker Compose
+
+To quickly set up your local infrastructure for development on your laptop using Docker containers, follow these three simple steps (assuming that you already have Docker and Docker-compose pre-installed):
+
+```bash
+# clone the repository
+git clone git@github.com:NLNOG/irrexplorer.git`
+# go to the dev directory
+cd dev/
+# start the development environment
+docker-compose -f docker-up -d
+```
+
+After executing these steps, you will have all the necessary services up and running for development:
+```bash
+% docker ps
+CONTAINER ID   IMAGE             COMMAND                  CREATED          STATUS                    PORTS                                            NAMES
+9b2ee198962f   dev-irrexplorer   "/app/irrexplorer/in…"   34 minutes ago   Up 33 minutes (healthy)   0.0.0.0:8000->8000/tcp                           irrexplorer
+3b08fb5ba0c8   dev-irrd          "/app/irrd/init"         34 minutes ago   Up 33 minutes (healthy)   0.0.0.0:8043->8043/tcp, 0.0.0.0:8080->8080/tcp   irrd
+67284918c7ea   postgres          "docker-entrypoint.s…"   34 minutes ago   Up 34 minutes (healthy)   5432/tcp                                         postgres_irre
+c689fad6d0e9   postgres          "docker-entrypoint.s…"   34 minutes ago   Up 34 minutes (healthy)   5432/tcp                                         postgres_irrd
+36414b39a412   redis             "docker-entrypoint.s…"   34 minutes ago   Up 34 minutes (healthy)   6379/tcp                                         redis_irrd
+```
+
+> You can can access IRR explorer web interface at http://localhost:8000/ and the API at http://localhost:8000/api/.
+
+> IRRd web interface available at http://localhost:8080/.
+
+> If you need to include or remove Routing Registries, check the file `irrd.yaml`/`sources`.
+
+If you need to access the containers, use the following command:
+```bash
+docker exec -it <container_name> /bin/sh
+```
+
+Since uvicorn is running in the foreground, you can access the logs with:
+```bash
+docker logs -f irrexplorer
+```
+
+Uvicorn supports auto-reloading, making it easy to check changes. If a complete reload is required, simply run:
+```bash
+docker container restart irrexplorer
+```
+
+ Tail container logs:
+```bash
+docker-compose logs -f --tail 100
+```
+
+
+#### To streamline your development workflow, we have included several convenient `Make` commands:
+
+`make clean`: Removes all unused Docker objects (containers, networks, volumes, and images) using `docker system prune --all`.
+
+`make start`: Starts the Docker containers defined in the `docker-compose.yml` file using `docker-compose up -d`.
+
+`make stop`: Stops and removes the Docker containers defined in the docker-compose.yml file using docker-compose down.
+
+`make rebuild`: Executes the stop, clean, and start commands in sequence to rebuild the development environment.
+
+`make dump_irrd_db`: Dumps the irrd database from the `postgres_irrd` container to a file named `irrdb.sql` using `docker exec` and `pg_dump`.
+
+`make dump_irre_db`: Dumps the irrexplorer database from the `postgres_irre` container to a file named `irrexplorer_db.sql` using `docker exec` and `pg_dump`.
+
+These commands provide a convenient way to manage the development environment, including starting, stopping, rebuilding, and dumping the databases.
+
+#### The infrastructure includes the following components:
+
+- PostgreSQL running for IRR Explorer using credentials specified in the docker-compose.yml;
+- PostgreSQL running for IRRd using credentials specified in the docker-compose.yml;
+- Redis used by IRRd;
+- IRRd caching registry data, keeping it updated using NRTM, and serving this data to IRR Explorer;
+- **Finally, IRR Explorer itself!**
+
+Happy coding!

--- a/dev/.env
+++ b/dev/.env
@@ -1,0 +1,4 @@
+DATABASE_URL=postgresql://irrexplorer:irrexplorer@postgres_irre:5432/irrexplorer?keepalives=1&keepalives_idle=5
+IRRD_ENDPOINT=http://irrd:8080/graphql/
+DEBUG=False
+REGISTROBR_URL=https://ftp.registro.br/pub/numeracao/origin/nicbr-asn-blk-latest.txt

--- a/dev/Dockerfiles/irrd4
+++ b/dev/Dockerfiles/irrd4
@@ -1,0 +1,28 @@
+# description="IRRd4 Docker Image"
+#
+# Dockerfile for the IRRd4 application.
+#
+# This Dockerfile sets up a Python 3.12.3 environment and installs the necessary dependencies for running the IRRd4 application. It copies an init script to the container, updates the package lists, installs build tools and other required packages, installs the IRRd4 package, and sets up the necessary directories and permissions.
+#
+# The resulting Docker image can be used to run the IRRd4 application in a containerized environment.
+
+FROM python:3.12.3-bookworm
+
+ARG IRRD_VERSION=4.4.4
+
+COPY init-irrd.sh /app/irrd/init
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential gcc gnupg dumb-init cron
+
+RUN pip install --no-cache-dir -U pip psycopg2 \
+    && pip install --no-cache-dir irrd==$IRRD_VERSION
+
+RUN apt-get clean autoclean \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /var/run/irrd
+RUN chown daemon:daemon /var/run/irrd
+
+CMD ["/app/irrd/init"]

--- a/dev/Dockerfiles/irrexplorer
+++ b/dev/Dockerfiles/irrexplorer
@@ -1,0 +1,23 @@
+# description="IRR explorer Docker Image"
+# Dockerfile for the IRR explorer application.
+#
+# This Dockerfile sets up a Python 3.12.3 environment with the necessary dependencies to run the IRR explorer application. It installs Git, Node.js, and npm, and then uses pip and yarn to install additional dependencies.
+#
+# The resulting Docker image can be used to install/run the IRR explorer application in a containerized environment.
+
+FROM python:3.12.3-bookworm
+
+WORKDIR /app/irrexplorer
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git nodejs npm 
+
+RUN pip install --no-cache-dir -U pip
+
+RUN npm install -g yarn
+
+RUN apt-get clean autoclean \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
+
+CMD ["/app/irrexplorer/init"]

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -1,0 +1,23 @@
+# Makefile for the IRR explorer development environment
+.PHONY: clean
+clean:
+	docker system prune --all
+
+.PHONY: start
+start:
+	docker-compose -f docker-compose.yml up -d
+
+.PHONY: stop
+stop:
+	docker-compose -f docker-compose.yml down
+
+.PHONY: rebuild
+rebuild: stop clean start
+
+.PHONY: dump_irrd_db
+dump_irrd_db:
+	docker exec postgres_irrd pg_dump -d irrd -U irrd -w > irrdb.sql
+
+.PHONY: dump_irre_db
+dump_irre_db:
+	docker exec postgres_irre pg_dump -d irrexplorer -U irrexplorer -w > irrexplorer_db.sql

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,0 +1,95 @@
+---
+# This Docker Compose configuration sets up a development environment for the IRRd and IRRExplorer applications. It includes the following services:
+#
+# - irrd: The IRRd (Internet Routing Registry Daemon) service, which is built from the Dockerfile located in the Dockerfiles/irrd4 directory. It mounts the irrd.yaml  configuration file and a volume for the PID file. It exposes ports 8080 and 8043 and has a health check that checks the / endpoint.
+# - postgres_irrd: A PostgreSQL database service for the IRRd application, with the database name, user, and password configured via environment variables. It mounts a volume for the database data and has a health check that checks the database connection.
+# - redis_irrd: A Redis service for the IRRd application, with a health check that checks the connection.
+# - irrexplorer: The IRRExplorer service, which is built from the Dockerfile located in the Dockerfiles/irrexplorer directory. It mounts the parent directory as the application code, the init-irrexplorer.sh script, and the .env file. It exposes port 8000 and has a health check that checks the / endpoint.
+# - postgres_irre: A PostgreSQL database service for the IRR explorer application, with the database name, user, and password configured via environment variables. It mounts a volume for the database data and has a health check that checks the database connection.
+#
+# The services are configured to depend on each other, with the irrd and irrexplorer services depending on the respective PostgreSQL and Redis services being healthy.
+services:
+  irrd:
+    build:
+      context: .
+      dockerfile: Dockerfiles/irrd4
+    container_name: irrd
+    volumes:
+      - ./irrd.yaml:/etc/irrd.yaml:ro
+      - ./data/irrd_pid:/var/run/irrd
+    ports:
+      - 8080:8080
+      - 8043:8043
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -LI localhost:8080" ]
+      interval: 15s
+      timeout: 15s
+      retries: 5
+    depends_on:
+      postgres_irrd:
+        condition: service_healthy
+      redis_irrd:
+        condition: service_healthy
+
+  postgres_irrd:
+    image: postgres
+    container_name: postgres_irrd
+    environment:
+      - "PGUSER=irrd"
+      - "POSTGRES_USER=irrd"
+      - "POSTGRES_PASSWORD=irrd"
+      - "POSTGRES_DB=irrd"
+    volumes:
+      - ./data/postgresql_irrd:/var/lib/postgresql/data
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -d irrd" ]
+      interval: 15s
+      timeout: 15s
+      retries: 5
+
+  redis_irrd:
+    image: redis
+    container_name: redis_irrd
+    healthcheck:
+      test: [ "CMD-SHELL", "redis-cli get nil" ]
+      interval: 60s
+      timeout: 5s
+      retries: 5
+
+  irrexplorer:
+    build:
+      context: .
+      dockerfile: Dockerfiles/irrexplorer
+    container_name: irrexplorer
+    ports:
+      - 8000:8000
+    volumes:
+      - ../:/app/irrexplorer
+      - ./init-irrexplorer.sh:/app/irrexplorer/init:ro
+      - ./.env:/app/irrexplorer/.env:ro
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -LI localhost:8000" ]
+      interval: 15s
+      timeout: 15s
+      retries: 5
+    depends_on:
+      postgres_irre:
+        condition: service_healthy
+      irrd:
+        condition: service_healthy
+
+  postgres_irre:
+    image: postgres
+    container_name: postgres_irre
+    environment:
+      - "PGUSER=irrexplorer"
+      - "POSTGRES_USER=irrexplorer"
+      - "POSTGRES_PASSWORD=irrexplorer"
+      - "POSTGRES_DB=irrexplorer"
+    volumes:
+      - ./data/postgresql_irre:/var/lib/postgresql/data
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -d irrexplorer" ]
+      interval: 15s
+      timeout: 15s
+      retries: 5

--- a/dev/init-irrd.sh
+++ b/dev/init-irrd.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# This script performs the following actions:
+# 1. Removes any existing PID files for the IRRD service from the /var/run/irrd directory.
+# 2. Upgrades the IRRD database using the configuration file located at /etc/irrd.yaml.
+# 3. Starts the IRRD service in the foreground using the configuration file located at /etc/irrd.yaml.
+
+rm /var/run/irrd/* >/dev/null 2>&1 || true
+
+irrd_database_upgrade --config=/etc/irrd.yaml
+exec /usr/local/bin/irrd --foreground --config=/etc/irrd.yaml

--- a/dev/init-irrexplorer.sh
+++ b/dev/init-irrexplorer.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# This script is responsible for setting up and running the IRRExplorer application.
+# 
+# It performs the following tasks:
+# - Installs the required Python dependencies using Poetry
+# - Runs the frontend installation and build commands
+# - Runs the database migrations using Alembic
+# - Schedules a cron job to periodically import data
+# - Starts the IRRExplorer application using the Uvicorn server
+# 
+# The script should be executed as part of the deployment process for the IRRExplorer application.
+
+pip install --no-cache-dir poetry
+poetry install
+poetry run frontend-install
+poetry run frontend-build
+poetry run alembic upgrade head
+
+/bin/echo "0 */3 * * * /usr/local/bin/poetry run import-data >> /var/log/cron.log 2>&1" >/etc/cron.d/poetry_import_data
+/bin/echo "" >>/etc/cron.d/poetry_import_data
+/bin/chmod 0644 /etc/cron.d/poetry_import_data
+/usr/bin/crontab /etc/cron.d/poetry_import_data
+/bin/touch /var/log/cron.log
+/usr/sbin/service cron start
+
+poetry run import-data&
+
+exec poetry run uvicorn irrexplorer.app:app --host 0.0.0.0 --port 8000 --workers 4 --reload

--- a/dev/irrd.yaml
+++ b/dev/irrd.yaml
@@ -1,0 +1,213 @@
+---
+# This YAML configuration file sets up the IRRd (Internet Routing Registry daemon) application. It defines the following key configuration settings:
+# 
+# - Database connection details for the PostgreSQL database used by IRRd.
+# - Authentication settings, including the GnuPG keyring location, a password override, and password hashing configuration.
+# - Logging settings, including the log level.
+# - Redis connection details.
+# - Process user and group.
+# - Preferences for route object updates and RPKI (Resource Public Key Infrastructure) integration.
+# - Access control lists for the HTTP and WHOIS servers.
+# - Server settings for the HTTP and WHOIS interfaces.
+# - Email notification settings, including the from address, SMTP server, and notification templates.
+# - Default and specific source configurations for various IRR (Internet Routing Registry) sources, including full import and NRTM (Notification of Changes) update settings.
+irrd:
+  database_url: postgresql://irrd:irrd@postgres_irrd:5432/irrd?keepalives=1&keepalives_idle=5
+  auth:
+      gnupg_keyring: /root/gnupg-keyring/
+      override_password: "so_safe"
+      webui_auth_failure_rate_limit: "30/hour"
+      password_hashers:
+          md5-pw: legacy
+  log:
+    level: DEBUG
+  redis_url: "redis://redis_irrd:6379"
+  piddir: /var/run/irrd/
+  user: daemon
+  group: daemon
+  route_object_preference:
+      update_timer: 3600
+  rpki:
+      roa_source: https://rpki.gin.ntt.net/api/export.json
+      roa_import_timer: 3600
+      pseudo_irr_remarks: |
+          This AS{asn} route object represents routing data retrieved
+          from the RPKI. This route object is the result of an automated
+          RPKI-to-IRR conversion process performed by IRRd.
+      notify_invalid_subject: route(6) objects in {sources_str} marked RPKI invalid
+      notify_invalid_header: |
+          This is to notify that {object_count} route(6) objects for which you are a
+          contact have been marked as RPKI invalid. This concerns
+          objects in the {sources_str} database.
+
+          You have received this message because your e-mail address is
+          listed in one or more of the tech-c or admin-c contacts, on
+          the maintainer(s) for these route objects.
+
+          The {object_count} route(6) objects listed below have been validated using
+          RPKI origin validation, and found to be invalid. This means that
+          these objects are no longer visible on the IRRd instance that
+          sent this e-mail.
+
+          This may affect routing filters based on queries to this IRRd
+          instance. It is also no longer possible to modify these objects.
+
+          To resolve this situation, create or modify ROA objects that
+          result in these route(6) being valid, or not_found. If this
+          happens, the route(6) objects will return to being visible.
+          You may also delete these objects if they are no longer
+          relevant.
+  access_lists:
+    http_database_status:
+      - "::/0"
+      - "0.0.0.0/0"
+  server:
+    http:
+      interface: "::0"
+      port: 8080
+      status_access_list: http_database_status
+      url: "http://localhost/"
+    whois:
+      interface: "::0"
+      port: 8043
+      # max_connections: 50
+  # log:
+  #   logfile_path: /var/log/irrd.log
+  #   level: WARNING
+  email:
+    from: irrd@example.com
+    smtp: localhost
+    footer: ''
+    notification_header: |
+      This is to notify you of changes in the {sources_str} database
+      or object authorisation failures.
+      
+      You may receive this message because you are listed in
+      the notify attribute on the changed object(s), because
+      you are listed in the mnt-nfy or upd-to attribute on a maintainer
+      of the object(s), or the upd-to attribute on the maintainer of a
+      parent of newly created object(s).
+  sources_default:
+    - RPKI
+    - ALTDB
+    - AFRINIC
+    - APNIC
+    - ARIN
+    - LACNIC
+    - RIPE
+    - RADB
+    - TC
+  sources:
+    # if you need to add a new routing registry, check https://irr.net/registry/
+    ALTDB:
+      # Run a full import at first, then periodic NRTM updates.
+      authoritative: false
+      keep_journal: true
+      import_source: "ftp://ftp.altdb.net/pub/altdb/altdb.db.gz"
+      import_serial_source: "ftp://ftp.altdb.net/pub/altdb/ALTDB.CURRENTSERIAL"
+      nrtm_host: whois.altdb.net
+      nrtm_port: 43
+      import_timer: 900 # every 15 minutes
+    AFRINIC:
+      # Run a full import at first, then periodic NRTM updates.
+      authoritative: false
+      keep_journal: true
+      import_source: "https://ftp.afrinic.net/pub/dbase/afrinic.db.gz"
+      import_serial_source: "https://ftp.afrinic.net/pub/dbase/AFRINIC.CURRENTSERIAL"
+      nrtm_host: whois.afrinic.net
+      nrtm_port: 43003
+      import_timer: 900 # every 15 minutes
+    APNIC:
+      # Run a full import at first, then periodic NRTM updates.
+      authoritative: false
+      keep_journal: true
+      import_source:
+        - "ftp://ftp.apnic.net/apnic/whois/apnic.db.as-block.gz"
+        - "ftp://ftp.apnic.net/apnic/whois/apnic.db.as-set.gz"
+        - "ftp://ftp.apnic.net/apnic/whois/apnic.db.aut-num.gz"
+        - "ftp://ftp.apnic.net/apnic/whois/apnic.db.domain.gz"
+        - "ftp://ftp.apnic.net/apnic/whois/apnic.db.filter-set.gz"
+        - "ftp://ftp.apnic.net/apnic/whois/apnic.db.inet-rtr.gz"
+        - "ftp://ftp.apnic.net/apnic/whois/apnic.db.inet6num.gz"
+        - "ftp://ftp.apnic.net/apnic/whois/apnic.db.inetnum.gz"
+        - "ftp://ftp.apnic.net/apnic/whois/apnic.db.irt.gz"
+        - "ftp://ftp.apnic.net/apnic/whois/apnic.db.key-cert.gz"
+        - "ftp://ftp.apnic.net/apnic/whois/apnic.db.limerick.gz"
+        - "ftp://ftp.apnic.net/apnic/whois/apnic.db.mntner.gz"
+        - "ftp://ftp.apnic.net/apnic/whois/apnic.db.organisation.gz"
+        - "ftp://ftp.apnic.net/apnic/whois/apnic.db.peering-set.gz"
+        - "ftp://ftp.apnic.net/apnic/whois/apnic.db.role.gz"
+        - "ftp://ftp.apnic.net/apnic/whois/apnic.db.route-set.gz"
+        - "ftp://ftp.apnic.net/apnic/whois/apnic.db.route.gz"
+        - "ftp://ftp.apnic.net/apnic/whois/apnic.db.route6.gz"
+        - "ftp://ftp.apnic.net/apnic/whois/apnic.db.rtr-set.gz"
+      import_serial_source: "ftp://ftp.apnic.net/pub/apnic/whois/APNIC.CURRENTSERIAL"
+      nrtm_host: whois.apnic.net
+      nrtm_port: 43
+      import_timer: 900 # every 15 minutes
+    ARIN:
+      # Run a full import at first, then periodic NRTM updates.
+      authoritative: false
+      keep_journal: true
+      import_source: "https://ftp.arin.net/pub/rr/arin.db.gz"
+      import_serial_source: "https://ftp.arin.net/pub/rr/ARIN.CURRENTSERIAL"
+      nrtm_host: rr.arin.net
+      nrtm_port: 43
+      import_timer: 900 # every 15 minutes
+    LACNIC:
+      # Run a full import at first, then periodic NRTM updates.
+      authoritative: false
+      keep_journal: true
+      import_source: "https://irr.lacnic.net/lacnic.db.gz"
+      import_serial_source: "https://irr.lacnic.net/LACNIC.CURRENTSERIAL"
+      nrtm_host: irr.lacnic.net
+      nrtm_port: 43
+      import_timer: 900 # every 15 minutes
+    RIPE:
+      # Run a full import at first, then periodic NRTM updates.
+      authoritative: false
+      keep_journal: true
+      import_source: 
+        - "https://ftp.ripe.net/ripe/dbase/split/ripe.db.as-block.gz"
+        - "https://ftp.ripe.net/ripe/dbase/split/ripe.db.as-set.gz"
+        - "https://ftp.ripe.net/ripe/dbase/split/ripe.db.aut-num.gz"
+        - "https://ftp.ripe.net/ripe/dbase/split/ripe.db.domain.gz"
+        - "https://ftp.ripe.net/ripe/dbase/split/ripe.db.filter-set.gz"
+        - "https://ftp.ripe.net/ripe/dbase/split/ripe.db.inet-rtr.gz"
+        - "https://ftp.ripe.net/ripe/dbase/split/ripe.db.inet6num.gz"
+        - "https://ftp.ripe.net/ripe/dbase/split/ripe.db.inetnum.gz"
+        - "https://ftp.ripe.net/ripe/dbase/split/ripe.db.irt.gz"
+        - "https://ftp.ripe.net/ripe/dbase/split/ripe.db.key-cert.gz"
+        - "https://ftp.ripe.net/ripe/dbase/split/ripe.db.mntner.gz"
+        - "https://ftp.ripe.net/ripe/dbase/split/ripe.db.organisation.gz"
+        - "https://ftp.ripe.net/ripe/dbase/split/ripe.db.peering-set.gz"
+        - "https://ftp.ripe.net/ripe/dbase/split/ripe.db.person.gz"
+        - "https://ftp.ripe.net/ripe/dbase/split/ripe.db.poem.gz"
+        - "https://ftp.ripe.net/ripe/dbase/split/ripe.db.poetic-form.gz"
+        - "https://ftp.ripe.net/ripe/dbase/split/ripe.db.role.gz"
+        - "https://ftp.ripe.net/ripe/dbase/split/ripe.db.route-set.gz"
+        - "https://ftp.ripe.net/ripe/dbase/split/ripe.db.route.gz"
+        - "https://ftp.ripe.net/ripe/dbase/split/ripe.db.route6.gz"
+        - "https://ftp.ripe.net/ripe/dbase/split/ripe.db.rtr-set.gz"
+      import_serial_source: "https://ftp.ripe.net/ripe/dbase/RIPE.CURRENTSERIAL"
+      nrtm_host: whois.ripe.net
+      nrtm_port: 4444
+      import_timer: 900 # every 15 minutes
+    RADB:
+      # Run a full import at first, then periodic NRTM updates.
+      authoritative: false
+      keep_journal: true
+      import_source: "ftp://ftp.radb.net/radb/dbase/radb.db.gz"
+      import_serial_source: "ftp://ftp.radb.net/radb/dbase/RADB.CURRENTSERIAL"
+      nrtm_host: nrtm.radb.net
+      nrtm_port: 43
+      import_timer: 900 # every 15 minutes
+    TC:
+      # Run a full import at first, then periodic NRTM updates.
+      authoritative: false
+      keep_journal: true
+      import_source: "https://ftp.bgp.net.br/tc.db.gz"
+      import_serial_source: "https://ftp.bgp.net.br/TC.CURRENTSERIAL"
+      nrtm_host: irr.bgp.net.br
+      nrtm_port: 43
+      import_timer: 900 # every 15 minutes


### PR DESCRIPTION
Creating a simple and straightforward development environment and infrastructure is crucial for attracting contributors to the project. I can attest to this based on my own experience when I decided to explore some of the open issues.

With this setup, any developer can create the environment using just three commands, assuming they already have Docker and Docker Compose pre-installed, without needing extensive knowledge of the required infrastructure:
```bash
# clone the repository
git clone git@github.com:NLNOG/irrexplorer.git`
# go to the dev directory
cd dev/
# start the development environment
docker-compose -f docker-up -d
```

The existing configurations, with minimal modifications, can also be used by those who need to deploy the IRR Explorer and IRRd4 services locally.

In a nutshell, the changes I am making include:
- Updating the documentation with the necessary instructions for setting up the development environment and testing changes;
- Adding scripts, configurations, Dockerfiles, docker-compose.yml, and other files required to create the development environment;
- Updating .gitignore to prevent the inclusion of unexpected files in commits;
- Creating a Makefile to assist with common daily operations.

Dependencies/blockers:
I have created [PR#339](https://github.com/NLNOG/irrexplorer/pull/339) to add py312 support to the IRR Explorer. We need this PR to be merged for the development environment to work as expected. If it is not accepted, we can fall back to using older Python versions, although that is not the ideal scenario.

Thank you for this fantastic project!