### PR TITLE
chore: prefer NIR over RIR

### DIFF
--- a/irrexplorer/api/collectors.py
+++ b/irrexplorer/api/collectors.py
@@ -154,18 +154,18 @@ class PrefixCollector:
         # This will hold the most relevant RIR statistic found
         relevant_rirstat = None
         # Flag to indicate if a NIR prefix has been found
-        NIR_PFX = False
+        nir_found = False
 
         # Iterate through all RIR statistics to find the one that overlaps with the given prefix
         for rirstat in self.rirstats:
             if rirstat.prefix.overlaps(prefix):
                 # Check if the current RIR is a NIR
-                if any(nir.name == rirstat.rir.name for nir in NIR):
+                if rirstat.rir and rirstat.rir.name in NIR:
                     # Set the flag if it's an NIR
-                    NIR_PFX = True
+                    nir_found = True
                     # Update the relevant RIR statistic
                     relevant_rirstat = rirstat
-                elif not NIR_PFX:
+                elif not nir_found:
                     # If no NIR has been found yet, update the relevant RIR
                     relevant_rirstat = rirstat
         # Return the RIR of the relevant statistic if found, otherwise return None

--- a/irrexplorer/api/collectors.py
+++ b/irrexplorer/api/collectors.py
@@ -21,6 +21,7 @@ from irrexplorer.settings import MINIMUM_PREFIX_SIZE, TESTING
 from irrexplorer.state import RIR, IPNetwork, RouteInfo, NIR
 
 SET_SIZE_LIMIT = 1000
+NIR_NAMES = [nir.name for nir in NIR]
 
 
 class PrefixCollector:
@@ -151,24 +152,15 @@ class PrefixCollector:
         Find the responsible RIR/NIR for a prefix, from self.rirstats previously
         gathered by _collect(), and prefer NIR over RIR.
         """
-        # This will hold the most relevant RIR statistic found
         relevant_rirstat = None
-        # Flag to indicate if a NIR prefix has been found
-        nir_found = False
 
-        # Iterate through all RIR statistics to find the one that overlaps with the given prefix
         for rirstat in self.rirstats:
             if rirstat.prefix.overlaps(prefix):
-                # Check if the current RIR is a NIR
-                if rirstat.rir and rirstat.rir.name in NIR:
-                    # Set the flag if it's an NIR
-                    nir_found = True
-                    # Update the relevant RIR statistic
-                    relevant_rirstat = rirstat
-                elif not nir_found:
-                    # If no NIR has been found yet, update the relevant RIR
-                    relevant_rirstat = rirstat
-        # Return the RIR of the relevant statistic if found, otherwise return None
+                relevant_rirstat = rirstat
+                if rirstat.rir and rirstat.rir.name in NIR_NAMES:
+                    # Break early if this is a NIR, as those take priority
+                    break
+        print(relevant_rirstat)
         return relevant_rirstat.rir if relevant_rirstat else None
 
 

--- a/irrexplorer/state.py
+++ b/irrexplorer/state.py
@@ -20,6 +20,12 @@ class RIR(enum.Enum):
     APNIC = "APNIC"
     REGISTROBR = "Registro.BR"
 
+class NIR(enum.Enum):
+    """
+    This enum classifies specific RIR entries that are considered NIRs.
+    Each entry in the enum represents a recognized NIR with its official designation.
+    """
+    REGISTROBR = "Registro.BR"  # Represents the Brazilian Internet Registry
 
 class RPKIStatus(enum.Enum):
     valid = "VALID"

--- a/irrexplorer/state.py
+++ b/irrexplorer/state.py
@@ -26,7 +26,7 @@ class NIR(enum.Enum):
     This enum classifies specific RIR entries that are considered NIRs.
     Each entry in the enum represents a recognized NIR with its official designation.
     """
-    REGISTROBR = "Registro.BR"  # Represents the Brazilian Internet Registry
+    REGISTROBR = RIR.REGISTROBR.value  # Represents the Brazilian Internet Registry
 
 
 class RPKIStatus(enum.Enum):

--- a/irrexplorer/state.py
+++ b/irrexplorer/state.py
@@ -20,12 +20,14 @@ class RIR(enum.Enum):
     APNIC = "APNIC"
     REGISTROBR = "Registro.BR"
 
+
 class NIR(enum.Enum):
     """
     This enum classifies specific RIR entries that are considered NIRs.
     Each entry in the enum represents a recognized NIR with its official designation.
     """
     REGISTROBR = "Registro.BR"  # Represents the Brazilian Internet Registry
+
 
 class RPKIStatus(enum.Enum):
     valid = "VALID"

--- a/irrexplorer/tests/test_prefixes_prefix.py
+++ b/irrexplorer/tests/test_prefixes_prefix.py
@@ -72,6 +72,14 @@ async def test_prefix_valid(client, httpserver):
         values={"prefix": "192.0.0.0/8", "rir": RIR.RIPENCC},
     )
     await client.app.state.database.execute(
+        query=tables.rirstats.insert(),
+        values={"prefix": "192.0.0.0/9", "rir": RIR.REGISTROBR},
+    )
+    await client.app.state.database.execute(
+        query=tables.rirstats.insert(),
+        values={"prefix": "192.0.0.0/7", "rir": RIR.RIPENCC},
+    )
+    await client.app.state.database.execute(
         query=tables.bgp.insert(),
         values={"prefix": "192.0.2.0/24", "asn": 64500},
     )
@@ -85,7 +93,7 @@ async def test_prefix_valid(client, httpserver):
             "goodnessOverall": 0,
             "categoryOverall": "danger",
             "bgpOrigins": [64500],
-            "rir": "RIPE NCC",
+            "rir": "Registro.BR",
             "rpkiRoutes": [
                 {
                     "rpkiStatus": "VALID",
@@ -116,7 +124,7 @@ async def test_prefix_valid(client, httpserver):
                 },
                 {
                     "category": "warning",
-                    "text": "Expected route object in RIPE, but only found in other IRRs",
+                    "text": "Expected route object in TC, but only found in other IRRs",
                 },
             ],
         }


### PR DESCRIPTION
**Overview**
This pull request introduces significant updates to the `PrefixCollector` class within the `irrexplorer/api/collectors.py` module, specifically aimed at refining the logic used to determine the responsible RIR/NIR for a given IP prefix. Additionally, it integrates a new NIR enum to the irrexplorer/state.py module to classify specific RIR entries that are considered National Internet Registries (NIRs).

**Changes**
- **PrefixCollector Logic Update**:
The method `_rir_for_prefix` has been overhauled to not only find the RIR responsible for a given prefix but also to prefer NIRs over other RIRs when applicable. This change ensures that NIRs are prioritized in the selection process, reflecting a more nuanced approach to registry classification.
The previous implementation used a generator expression to filter relevant RIR statistics. The new implementation uses a more explicit loop that allows for additional checks and prioritization of NIRs.

- **Introduction of NIR Enum**:
A new enum, `NIR`, has been added to classify specific entries as National Internet Registries. This addition allows the system to easily identify and prioritize NIRs during the RIR selection process.
The `NIR` enum currently includes `REGISTROBR` as a member, representing the Brazilian Internet Registry.

**Benefits**
- **Improved Accuracy**: By prioritizing NIRs, the system more accurately reflects the hierarchical structure of internet registries.
- **Enhanced Readability and Maintainability**: The refactored code in `_rir_for_prefix` uses explicit control structures that improve the readability and maintainability of the code.
- **Scalability**: The introduction of the NIR enum provides a scalable way to add more NIRs in the future, should they become relevant.

**Impact**
This update requires careful review to ensure that the prioritization logic correctly reflects the intended behavior, especially in edge cases where multiple RIRs might overlap with a given prefix.
Additional tests may be necessary to cover the new logic paths and ensure that NIR prioritization functions as expected.

**Testing**
The changes have been locally tested to ensure that the new logic correctly identifies and prioritizes NIRs.
Further integration testing is recommended to validate the changes across the system.

This update aims to enhance the functionality of the IRRExplorer by refining how it identifies the responsible RIRs, ensuring that NIRs are given precedence in a manner that aligns with global internet governance practices.

Additionally, this PR resolves the issues found in [Issue #308](https://github.com/NLNOG/irrexplorer/issues/308) and [Issue #263](https://github.com/NLNOG/irrexplorer/issues/263), enhancing the accuracy and functionality of the IRRExplorer.

<img width="1422" alt="image" src="https://github.com/NLNOG/irrexplorer/assets/13142853/c3ccbf28-6469-40c4-b8cb-55d9178bed3a">

<img width="1410" alt="image" src="https://github.com/NLNOG/irrexplorer/assets/13142853/1da63a3e-505c-457f-84c5-44151c7dce8a">


Thanks for maintaining this amazing project! =D