### PR TITLE
Fix #90 - Slightly clean up error message for gateway timeout

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -33,7 +33,7 @@ export async function getMetadata() {
         return {data: response.data, url: url};
     } catch (exc) {
         if (exc.response) {
-            return {error: exc.response.data};
+            return {error: 'Error: unable to reach API: ' + exc.response.data}
         }
         return {error: 'Error: unable to reach API'}
     }
@@ -45,7 +45,7 @@ export async function cleanQuery(query) {
         return response.data;
     } catch (exc) {
         if (exc.response) {
-            return {error: exc.response.data};
+            return {error: 'Error: unable to reach API: ' + exc.response.data}
         }
         return {error: 'Error: unable to reach API'}
     }


### PR DESCRIPTION
Extracting the HTML is non trivial, and I want to keep it in so
that we don't omit useful debug data. This adds a text that makes
it slightly less ugly.
