### PR TITLE
Fix #172 - Extend the modal with a warning and link to website

### DIFF
--- a/frontend/src/components/prefixTable/whoisModal.jsx
+++ b/frontend/src/components/prefixTable/whoisModal.jsx
@@ -11,6 +11,7 @@ class WhoisModal extends Component {
             modalRef: React.createRef(),
             titleRef: React.createRef(),
             queryRef: React.createRef(),
+            queryUrlRef: React.createRef(),
             rpslTextRef: React.createRef(),
             rpkiAlertRef: React.createRef(),
         };
@@ -25,17 +26,25 @@ class WhoisModal extends Component {
     }
 
     openWithContent = (prefix, asn, sourceName, rpslText, rpkiStatus) => {
-        const {bootstrapModal, titleRef, queryRef, rpslTextRef, rpkiAlertRef} = this.modal;
+        const {bootstrapModal, titleRef, queryRef, queryUrlRef, rpslTextRef, rpkiAlertRef} = this.modal;
         const whoisServer = config.whoisServers[sourceName];
+        const whoisUrl = config.whoisUrls[sourceName];
         titleRef.current.innerText = `AS${asn} / ${prefix}`;
         queryRef.current.innerText = `whois -h ${whoisServer} ${prefix}`;
+        if (whoisUrl) {
+            queryUrlRef.current.innerText = `Open this object on the ${sourceName} website`;
+            queryUrlRef.current.href = whoisUrl.replace('SEARCHPLACEHOLDER', `${prefix}AS${asn}`);
+            queryUrlRef.current.hidden = false;
+        } else {
+            queryUrlRef.current.hidden = true;
+        }
         rpslTextRef.current.innerText = rpslText;
         rpkiAlertRef.current.hidden = rpkiStatus !== 'INVALID'
         bootstrapModal.show();
     }
 
     render() {
-        const {modalRef, titleRef, queryRef, rpslTextRef, rpkiAlertRef} = this.modal;
+        const {modalRef, titleRef, queryRef, queryUrlRef, rpslTextRef, rpkiAlertRef} = this.modal;
 
         return (
             <div className="modal fade" tabIndex="-1" ref={modalRef}>
@@ -49,6 +58,13 @@ class WhoisModal extends Component {
                         <div className="modal-body">
                             <p className="font-monospace" ref={queryRef}/>
                             <pre className="text-light bg-dark" ref={rpslTextRef}/>
+                            <p>
+                                The object shown below is mirrored, and may be modified or slightly outdated.
+                                You can get the latest version directly from the IRR registry.
+                            </p>
+                            <p>
+                                <a className="btn btn-success" href="/" ref={queryUrlRef}>#</a><br/>
+                            </p>
                             <div className="alert alert-warning" role="alert" ref={rpkiAlertRef}>
                                 This route object is RPKI-invalid, and may be filtered out
                                 of whois query output by default.

--- a/frontend/src/config.json
+++ b/frontend/src/config.json
@@ -23,5 +23,13 @@
     "RGNET": "whois.rg.net",
     "RIPE": "whois.ripe.net",
     "TC": "whois.bgp.net.br"
+  },
+  "whoisUrls": {
+    "AFRINIC": "https://afrinic.net/whois-web/public/plain-text?sourceDatabases=AFRINIC&id=SEARCHPLACEHOLDER&type=route,route6",
+    "IDNIC": "https://idnic.net/service/whois/search?key=SEARCHPLACEHOLDER",
+    "LACNIC": "https://query.milacnic.lacnic.net/search?id=SEARCHPLACEHOLDER",
+    "RIPE": "https://apps.db.ripe.net/db-web-ui/query?searchtext=SEARCHPLACEHOLDER",
+    "RADB": "https://www.radb.net/query?keywords=SEARCHPLACEHOLDER",
+    "TC": "https://bgp.net.br/whois.html?q=SEARCHPLACEHOLDER"
   }
 }


### PR DESCRIPTION
Seems not that many IRRs have a website for querying we can link to (a few are SPAs with no outside links). Added the ones I could find so far, should be easy to add more if I missed something.