### PR TITLE
Fix #281 - Render supernet table by smallest prefix first

### DIFF
--- a/frontend/src/components/asnQuery.jsx
+++ b/frontend/src/components/asnQuery.jsx
@@ -68,6 +68,7 @@ class ASNQuery extends Component {
                     reducedColour={reducedColour}
                     filterWarningError={filterWarningError}
                     apiCallUrl={this.state.apiCallUrl}
+                    defaultSortSmallestFirst={true}
                 />
                 <h2 className="h3 mt-4">
                     Included in the following AS sets:

--- a/frontend/src/components/prefixQuery.jsx
+++ b/frontend/src/components/prefixQuery.jsx
@@ -75,6 +75,7 @@ class PrefixQuery extends Component {
                         apiCallUrl={leastSpecificOverlapPrefixes.apiCallUrl}
                         reducedColour={reducedColour}
                         filterWarningError={filterWarningError}
+                        defaultSortSmallestFirst={true}
                     />
                 </>}
             </>

--- a/frontend/src/components/prefixTable/prefixTable.jsx
+++ b/frontend/src/components/prefixTable/prefixTable.jsx
@@ -27,8 +27,9 @@ class PrefixTable extends Component {
     }
 
     updateState() {
+        const defaultKey = this.props.defaultSortSmallestFirst ? 'prefixSmallestFirst' : 'prefix';
         this.setState({
-            sortedPrefixesData: sortPrefixesDataBy(this.props.prefixesData, 'prefix'),
+            sortedPrefixesData: sortPrefixesDataBy(this.props.prefixesData, defaultKey),
             irrSourceColumns: findIrrSourceColumns(this.props.prefixesData),
         });
 
@@ -91,6 +92,7 @@ PrefixTable.propTypes = {
     reducedColour: PropTypes.bool,
     filterWarningError: PropTypes.bool,
     apiCallUrl: PropTypes.string,
+    defaultSortSmallestFirst: PropTypes.bool,
 };
 
 

--- a/frontend/src/utils/prefixData.js
+++ b/frontend/src/utils/prefixData.js
@@ -33,7 +33,8 @@ export function findLeastSpecific(queryPrefix, prefixesData) {
 }
 
 export function sortPrefixesDataBy(prefixesData, key, order = 'asc') {
-    if (key === 'prefix') key = 'prefixSortKey';
+    if (key === 'prefix') key = 'prefixSortKeyIpPrefix';
+    if (key === 'prefixSmallestFirst') key = 'prefixSortKeyReverseNetworklenIp';
     if (key === 'bgpOrigins') key = 'bgpOrigins.0';
     if (key === 'rpkiRoutes') key = 'rpkiRoutes.0.asn';
     if (key.startsWith('irrRoutes')) key += '.0.asn';

--- a/irrexplorer/api/interfaces.py
+++ b/irrexplorer/api/interfaces.py
@@ -84,14 +84,17 @@ class PrefixSummary:
     # category_overall converted into a number for sorting
     goodness_overall: Optional[int] = 0
     # Numerical IP plus prefix length. Used as sorting key in the frontend.
-    prefix_sort_key: Optional[str] = None
+    prefix_sort_key_ip_prefix: Optional[str] = None
+    # (128 - prefix length) plus numerical IP. Used as sorting key in the frontend.
+    prefix_sort_key_reverse_networklen_ip: Optional[str] = None
 
     def finalise_status(self):
         """
         Set a few properties that depend on others.
         Should be called before returning to the user.
         """
-        self.prefix_sort_key = f"{self.prefix.network_address._ip}/{self.prefix.prefixlen}"
+        self.prefix_sort_key_ip_prefix = f"{self.prefix.network_address._ip}/{self.prefix.prefixlen}"
+        self.prefix_sort_key_reverse_networklen_ip = f"{128 - self.prefix.prefixlen}-{self.prefix.network_address._ip}"
         if not self.messages:
             self.success("Everything looks good")
 

--- a/irrexplorer/api/tests/test_report.py
+++ b/irrexplorer/api/tests/test_report.py
@@ -40,7 +40,8 @@ def test_report_good():
     assert summary.messages == [
         ReportMessage(category=MessageCategory.SUCCESS, text="Everything looks good"),
     ]
-    assert summary.prefix_sort_key == "42540766411282592856903984951653826560/48"
+    assert summary.prefix_sort_key_ip_prefix == "42540766411282592856903984951653826560/48"
+    assert summary.prefix_sort_key_reverse_networklen_ip == "80-42540766411282592856903984951653826560"
 
 
 def test_report_no_origin():

--- a/irrexplorer/tests/test_prefixes_asn.py
+++ b/irrexplorer/tests/test_prefixes_asn.py
@@ -65,7 +65,8 @@ async def test_asn_valid(client, httpserver):
         "directOrigin": [
             {
                 "prefix": "192.0.2.0/24",
-                "prefixSortKey": "3221225984/24",
+                "prefixSortKeyIpPrefix": "3221225984/24",
+                "prefixSortKeyReverseNetworklenIp": "104-3221225984",
                 "goodnessOverall": 0,
                 "categoryOverall": "danger",
                 "bgpOrigins": [64500],
@@ -108,7 +109,8 @@ async def test_asn_valid(client, httpserver):
         "overlaps": [
             {
                 "prefix": "192.0.2.128/25",
-                "prefixSortKey": "3221226112/25",
+                "prefixSortKeyIpPrefix": "3221226112/25",
+                "prefixSortKeyReverseNetworklenIp": "103-3221226112",
                 "goodnessOverall": 0,
                 "categoryOverall": "danger",
                 "bgpOrigins": [64501],
@@ -144,7 +146,8 @@ async def test_asn_no_irr_data(client, httpserver):
         "directOrigin": [
             {
                 "prefix": "192.0.2.0/24",
-                "prefixSortKey": "3221225984/24",
+                "prefixSortKeyIpPrefix": "3221225984/24",
+                "prefixSortKeyReverseNetworklenIp": "104-3221225984",
                 "goodnessOverall": 0,
                 "categoryOverall": "danger",
                 "bgpOrigins": [64500],

--- a/irrexplorer/tests/test_prefixes_prefix.py
+++ b/irrexplorer/tests/test_prefixes_prefix.py
@@ -89,7 +89,8 @@ async def test_prefix_valid(client, httpserver):
     expected = [
         {
             "prefix": "192.0.2.0/24",
-            "prefixSortKey": "3221225984/24",
+            "prefixSortKeyIpPrefix": "3221225984/24",
+            "prefixSortKeyReverseNetworklenIp": "104-3221225984",
             "goodnessOverall": 0,
             "categoryOverall": "danger",
             "bgpOrigins": [64500],
@@ -144,7 +145,8 @@ async def test_prefix_valid_rpki_as0(client, httpserver):
     expected = [
         {
             "prefix": "192.0.2.0/24",
-            "prefixSortKey": "3221225984/24",
+            "prefixSortKeyIpPrefix": "3221225984/24",
+            "prefixSortKeyReverseNetworklenIp": "104-3221225984",
             "goodnessOverall": 0,
             "categoryOverall": "danger",
             "bgpOrigins": [],
@@ -185,7 +187,8 @@ async def test_prefix_no_data(client, httpserver):
     expected = [
         {
             "prefix": "192.0.2.0/24",
-            "prefixSortKey": "3221225984/24",
+            "prefixSortKeyIpPrefix": "3221225984/24",
+            "prefixSortKeyReverseNetworklenIp": "104-3221225984",
             "goodnessOverall": 0,
             "categoryOverall": "danger",
             "bgpOrigins": [64500],


### PR DESCRIPTION
@teunvink do we have some sample prefixes where this problem was seen? I've implemented the change we decided on, sorting the supernet table by smallest prefix size first, IP second, by default. But I'm not sure it's helping.
