### PR TITLE
docs: add IRRexplorer CLI to third-party tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,3 +149,15 @@ This also allow auto reloading.
 To run tests, run `yarn build` (or `poetry run frontend-build`) at least once
 (that build is used for static serving tests), activate the virtualenv,
 then run `pytest`.
+
+### Third-party Tools
+
+#### IRRexplorer CLI
+A command-line interface to query and explore IRR & BGP data from IRRexplorer.net in real-time.
+
+Installation:
+```bash
+pip install irrexplorer-cli
+```
+
+For full documentation and usage examples, visit: https://github.com/kiraum/irrexplorer-cli


### PR DESCRIPTION
Hello,

I greatly enjoy the data provided by the IRRexplorer project, but sometimes needed a faster way to query the data from the shell. For this reason, I built and published a CLI tool to consume IRRexplorer. This CLI tool provides a simple way for users to query IRRexplorer data directly from the command line, supporting both prefix and ASN lookups with multiple output formats.

I'd like to add a reference to this tool in the documentation to help others consume IRRexplorer data, regardless of their environment. If this aligns with the project's goals, I believe it would be valuable for the community. If not, please feel free to close this PR.

The tool is published on PyPI and fully documented on GitHub.

* PuPI: https://pypi.org/project/irrexplorer-cli
* Github repository: https://github.com/kiraum/irrexplorer-cli

Thanks to the NLNOG foundation for maintaining this amazing project! =D