### PR TITLE
Display last update time in UTC

### DIFF
--- a/frontend/src/components/common/metadata.jsx
+++ b/frontend/src/components/common/metadata.jsx
@@ -5,6 +5,7 @@ import Spinner from "./spinner";
 import api from "../../services/api";
 import TableFooter from "./tableFooter";
 import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
 
 const relativeTime = require('dayjs/plugin/relativeTime');
 
@@ -57,9 +58,10 @@ class Metadata extends Component {
 
     renderDate(date) {
         dayjs.extend(relativeTime);
+        dayjs.extend(utc);
         const date_parsed = dayjs(date);
         const format = 'YYYY-MM-DD HH:mm';
-        return `${date_parsed.fromNow()} (${date_parsed.format(format)} UTC)`
+        return `${date_parsed.fromNow()} (${date_parsed.utc().format(format)} UTC)`
     }
 
     renderTablePlaceholder(placeholder) {


### PR DESCRIPTION
We noticed that https://irrexplorer.nlnog.net/status/ shows a local time while indicating that it is in UTC. Adding this dayjs plugin ensures that the time is actually UTC.

Alternatively, we could format the timezone using days.